### PR TITLE
chore: update deps.

### DIFF
--- a/.github/workflows/check-code.yaml
+++ b/.github/workflows/check-code.yaml
@@ -17,9 +17,9 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
+      - uses: "actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3" # v6.0.0
 
-      - uses: "golangci/golangci-lint-action@0a35821d5c230e903fcfe077583637dea1b27b47" # v9.0.0
+      - uses: "golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601" # v9.1.0
         with:
           version: "latest"
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
+      - uses: "actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3" # v6.0.0
 
       - name: "Run spell check"
         run: "make spell-check"
@@ -46,9 +46,9 @@ jobs:
           - "1.24"
           - "1.25"
     steps:
-      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
+      - uses: "actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3" # v6.0.0
 
-      - uses: "actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00" # v6.0.0
+      - uses: "actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c" # v6.1.0
         with:
           go-version: "${{ matrix.go }}"
 

--- a/.github/workflows/scan-vulnerabilities.yaml
+++ b/.github/workflows/scan-vulnerabilities.yaml
@@ -15,9 +15,9 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
+      - uses: "actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3" # v6.0.0
 
-      - uses: "actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00" # v6.0.0
+      - uses: "actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c" # v6.1.0
         with:
           go-version: "1.25"
 


### PR DESCRIPTION
This pull request updates several GitHub Actions in the workflow configuration files to use newer, more secure versions. The changes focus on keeping our CI/CD pipeline up-to-date and improving reliability by using the latest stable releases of key actions.

**GitHub Actions Version Upgrades:**

* Upgraded `actions/checkout` from v5.0.0 to v6.0.0 in `.github/workflows/check-code.yaml` and `.github/workflows/scan-vulnerabilities.yaml` for improved performance and security. [[1]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L20-R22) [[2]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L34-R34) [[3]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L49-R51) [[4]](diffhunk://#diff-cc9d9d3c0c78f6b5ef4c43e5c23501e6420a0e25eff660af96e7fdaee9e519ddL18-R20)
* Upgraded `actions/setup-go` from v6.0.0 to v6.1.0 in `.github/workflows/check-code.yaml` and `.github/workflows/scan-vulnerabilities.yaml` to ensure compatibility with the latest Go versions. [[1]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L49-R51) [[2]](diffhunk://#diff-cc9d9d3c0c78f6b5ef4c43e5c23501e6420a0e25eff660af96e7fdaee9e519ddL18-R20)
* Updated `golangci/golangci-lint-action` from v9.0.0 to v9.1.0 in `.github/workflows/check-code.yaml` for improved linting and bug fixes.